### PR TITLE
Match with sample data and compute concentration changes over time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 # Script outputs
 outputs/
+.Rproj.user

--- a/0-functions.R
+++ b/0-functions.R
@@ -22,8 +22,9 @@ library(tidyr)
 # Parameters for key analytical choices
 # Defined here so they can be easily used in code AND manuscript
 MAX_MEASUREMENT_TIME <- 120 # anything longer than this is an ambient sample
-MAX_MINCONC_TIME <- 10     # the minimum concentration has to occur in first 10 s
-MAX_MAXCONC_TIME <- 45     # the maximum concentration has to occur in first 45 s
+MIN_FLUXCALC_TIME <- 5     # the minimum concentration has to occur in first 10 s
+MAX_FLUXCALC_TIME <- 60     # the maximum concentration has to occur in first 45 s
+
 OUTLIER_GROUPS   <- 10     # Divide data into date groups and identify outliers in each
 CO2_EXCLUDE_DEVS <- 5.0    # CO2 outlier boundary, in mean absolute deviations
 CH4_EXCLUDE_DEVS <- 10.0   # CH4 outlier boundary, in mean absolute deviations

--- a/3-summarize (qc).r
+++ b/3-summarize (qc).r
@@ -21,7 +21,7 @@ openlog(file.path(outputdir(), paste0(SCRIPTNAME, ".log.txt")), sink = TRUE) # o
 printlog("Welcome to", SCRIPTNAME)
 
 printlog("Reading in raw data...")
-read_csv(RAWDATA_FILE, col_types = "ccccidddd") %>%
+read_csv(RAWDATA_FILE) %>%
   # Convert date/time to POSIXct
   mutate(DATETIME = ymd_hms(paste(DATE, TIME))) %>%
   select(-DATE, -TIME) %>%
@@ -49,21 +49,72 @@ rawdata %>%
   mutate(elapsed_seconds = as.double(difftime(DATETIME, min(DATETIME), units = "secs"))) ->
   rawdata_samples
 
-printlog("Removing ambient samples...")
+printlog("Reading key data...")
+library(readxl)
+keydata <- readxl::read_excel("Sample_ValveKey.xlsx") %>% 
+  mutate(Valve = as.integer(Valve))
+
+printlog("Removing ambient samples amd matching with valve data...")
 AMBIENT_VALVE <- 16
 rawdata_samples %>%
+  ungroup %>% 
   filter(MPVPosition != AMBIENT_VALVE) %>% 
+  left_join(keydata, by = c("MPVPosition" = "Valve")) %>% 
   group_by(samplenum) %>%
   #  filter(max(elapsed_seconds) <= MAX_MEASUREMENT_TIME) %>%
   print_dims("rawdata_samples") ->
   rawdata_samples
 
+# Not sure why there are duplicate CO2 concentrations, but remove
+rawdata_samples %>% 
+  filter(elapsed_seconds < 60) %>% 
+  group_by(samplenum, MPVPosition, Sample, elapsed_seconds) %>% 
+  summarise(CO2_dry = mean(CO2_dry), CH4_dry = mean(CH4_dry), DATETIME = mean(DATETIME)) ->
+  rawdata_samples_trunc
+
+unmatched <- filter(rawdata_samples_trunc, is.na(Sample))
+printlog(nrow(unmatched), "unmatched observations; valve numbers", 
+         paste(unique(unmatched$MPVPosition), collapse = " "))
+rawdata_samples_trunc <- filter(rawdata_samples_trunc, !is.na(Sample))
+
 printlog("Visualizing...")
-p <- ggplot(rawdata_samples, aes(x = elapsed_seconds, color = yday(DATETIME), group = samplenum)) +
-  facet_wrap(~MPVPosition, scales = "free_y") + 
-  ggtitle("Concentration by date and valve")
+p <- ggplot(rawdata_samples_trunc, aes(x = elapsed_seconds, color = Sample, group = samplenum)) +
+  ggtitle("Concentration by sampling time and valve")
 print(p + geom_line(aes(y = CO2_dry)) + xlim(c(0, 60)))
 save_plot("co2_by_valve", ptype = ".png")
 print(p + geom_line(aes(y = CH4_dry)) + xlim(c(0, 60)))
 save_plot("ch4_by_valve", ptype = ".png")
 
+printlog("Computing concentration change rates...")
+# We use a robust linear regression here
+rawdata_samples_trunc %>% 
+  filter(elapsed_seconds >= MIN_FLUXCALC_TIME, elapsed_seconds <= MAX_FLUXCALC_TIME) %>% 
+  group_by(samplenum) %>% 
+  do(m = lm(CO2_dry ~ elapsed_seconds, data = .)) %>% 
+  summarise(samplenum = samplenum,
+            intercept = m$coefficients[1], slope = m$coefficients[2], r2 = summary(m)$adj.r.squared, rse = summary(m)$sigma) ->
+  slopes
+
+
+rawdata_samples_trunc %>% 
+  group_by(samplenum) %>% 
+  summarise(DATETIME = mean(DATETIME), Sample = unique(Sample)) %>% 
+  left_join(slopes, by = "samplenum") ->
+  summarised_data
+
+# Diagnostic plots
+
+qc1 <- qplot(DATETIME, slope, data = summarised_data, geom = "line") + 
+  facet_wrap(~Sample, scales = "free") +
+  theme(axis.text.x = element_text(size = 6))
+save_plot("qc1-slopes", qc1)
+qc2 <- qplot(DATETIME, r2, data = summarised_data, geom = "line") + 
+  facet_wrap(~Sample, scales = "free") +
+  theme(axis.text.x = element_text(size = 6))
+save_plot("qc1-r2", qc2)
+
+
+save_data(summarised_data)
+
+printlog("All done.")
+closelog()

--- a/3-summarize (qc).r
+++ b/3-summarize (qc).r
@@ -107,14 +107,19 @@ rawdata_samples_trunc %>%
 qc1 <- qplot(DATETIME, slope, data = summarised_data, geom = "line") + 
   facet_wrap(~Sample, scales = "free") +
   theme(axis.text.x = element_text(size = 6))
-save_plot("qc1-slopes", qc1)
+print(qc1)
+save_plot("qc1-slopes")
 qc2 <- qplot(DATETIME, r2, data = summarised_data, geom = "line") + 
   facet_wrap(~Sample, scales = "free") +
   theme(axis.text.x = element_text(size = 6))
-save_plot("qc1-r2", qc2)
+print(qc2)
+save_plot("qc1-r2")
+qc3 <- qplot(slope, r2, data = summarised_data, color = Sample)  + xlim(c(0, 250))
+print(qc3)
+save_plot("qc3-slope_r2")
 
 
-save_data(summarised_data)
+save_data(summarised_data, scriptfolder = FALSE)
 
 printlog("All done.")
 closelog()


### PR DESCRIPTION
Hi @AditiGit - I've added code to match the Licor data with the key data (sample/valve) you provided, compute concentration change over time, and make some (better) diagnostic plots.

This one shows, for each sample, the ppm CO2/second rate:
![qc1-slopes](https://user-images.githubusercontent.com/1956468/42072099-b59a58de-7b13-11e8-96a6-6af620684d34.png)

This plots change rate against R2 of the linear fit. As you can see, there are many problematic measurements we'll want to investigate and/or drop:
![qc3-slope_r2](https://user-images.githubusercontent.com/1956468/42072135-d69b6a14-7b13-11e8-89c1-4a27106c2951.png)
